### PR TITLE
Clearing away JSHint errors

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,5 @@
+{
+  "node": true,
+  "asi": true,
+  "laxcomma": true
+}


### PR DESCRIPTION
I applied [JSHint](http://jshint.com/) to look for potential sources of bugs. Originally, it printed about 50 errors. These turned out to be mostly stylistic, so I cut them out with `.jshintrc`. Now when you run JSHint, it only prints two errors:

```
$ jshint .
index.js: line 1, col 1, Missing semicolon.
index.js: line 183, col 14, Possible strict violation.

2 errors
```

I've left the remaining errors alone for now, out of respect for your coding style.

What do you think?
