### PR TITLE
Fix various bugs with connection pool handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,23 +81,29 @@ TunnelingAgent.prototype.addRequest = function addRequest(req, options) {
 
   if (self.sockets.length >= this.maxSockets) {
     // We are over limit so we'll add it to the queue.
-    self.requests.push({host: host, port: port, request: req})
+    self.requests.push({host: options.host, port: options.port, request: req})
     return
   }
 
   // If we are under maxSockets create a new one.
-  self.createSocket({host: options.host, port: options.port, request: req}, function(socket) {
+  self.createConnection({host: options.host, port: options.port, request: req})
+}
+
+TunnelingAgent.prototype.createConnection = function createConnection(pending) {
+  var self = this
+
+  self.createSocket(pending, function(socket) {
     socket.on('free', onFree)
     socket.on('close', onCloseOrRemove)
     socket.on('agentRemove', onCloseOrRemove)
-    req.onSocket(socket)
+    pending.request.onSocket(socket)
 
     function onFree() {
-      self.emit('free', socket, options.host, options.port)
+      self.emit('free', socket, pending.host, pending.port)
     }
 
     function onCloseOrRemove(err) {
-      self.removeSocket()
+      self.removeSocket(socket)
       socket.removeListener('free', onFree)
       socket.removeListener('close', onCloseOrRemove)
       socket.removeListener('agentRemove', onCloseOrRemove)
@@ -182,9 +188,7 @@ TunnelingAgent.prototype.removeSocket = function removeSocket(socket) {
   if (pending) {
     // If we have pending requests and a socket gets closed a new one
     // needs to be created to take over in the pool for the one that closed.
-    this.createSocket(pending, function(socket) {
-      pending.request.onSocket(socket)
-    })
+    this.createConnection(pending)
   }
 }
 
@@ -197,6 +201,7 @@ function createSecureSocket(options, cb) {
       , socket: socket
       }
     ))
+    self.sockets[self.sockets.indexOf(socket)] = secureSocket
     cb(secureSocket)
   })
 }


### PR DESCRIPTION
- Adding requests to the queue used wrong parameters.
- onCloseOrRemove() didn't remove sockets from the pool.
- When using TLS, the pool contained the underlying connection instead
  of the TLS wrapped connection, causing connections to never be
  removed.
- When a connection was closed and removeSocket() created a new socket
  to process requests in the queue, the event handlers were not attached
  to the new socket, causing the new socket to not be removed from the
  pool when it closed.
