### PR TITLE
Specify license on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,6 @@
   "optionalDependencies": {},
   "engines": {
     "node": "*"
-  }
+  },
+  "license": "Apache 2.0"
 }


### PR DESCRIPTION
Hey there,

We're using an automated tool called License Finder (https://github.com/pivotal/LicenseFinder) and your node module comes up as "Unknown". By adding the license to package.json you would help immensely users of this and other automated tools to figure out whether a module can be used inside another project.

Thanks!
