### PR TITLE
set the defaultPort to 443 for https agents

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ function httpsOverHttp(options) {
   var agent = new TunnelingAgent(options)
   agent.request = http.request
   agent.createSocket = createSecureSocket
+  agent.defaultPort = 443
   return agent
 }
 
@@ -38,6 +39,7 @@ function httpsOverHttps(options) {
   var agent = new TunnelingAgent(options)
   agent.request = https.request
   agent.createSocket = createSecureSocket
+  agent.defaultPort = 443
   return agent
 }
 


### PR DESCRIPTION
Without this, the library tells the proxy
to CONNECT to port 80 on the server, even
for https urls, and then continues to talk SSL.
This of course confuses the server and leads
to all kind of failures.

Problem is, the underlying network library
(_http_client) defaults to port 80, if there
is no port in the URL, and the agent does not
specify a default either. It never even looks
at the protocol.

Example:
Trying to connect to:
  https://raw.github.com/
will send this connect string to the https_proxy:
  CONNECT raw.github.com:80 HTTP/1.1
but of course it should be:
  CONNECT raw.github.com:443 HTTP/1.1

Trying to connect to:
  https://raw.github.com:443/
already worked before this change.
