### PR TITLE
emit event on CONNECT response

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,8 @@ TunnelingAgent.prototype.createSocket = function createSocket(options, cb) {
     connectReq.removeAllListeners()
     socket.removeAllListeners()
 
+    options.request.emit('tunnel_connect_response', res)
+
     if (res.statusCode === 200) {
       assert.equal(head.length, 0)
       debug('tunneling connection has established')


### PR DESCRIPTION
Emit the tunnel CONNECT response to the parent request. This makes it possible to debug or gain insights in the tunneling process. 

Example that logs a response header from the proxy service:
```
const onTunnelReponse = t => console.log(t.headers['x-proxy-header'])
const onRequest = r => r.once('tunnel_connect_response', onTunnelReponse)

request.get({
    url,
    proxy: `http://${puser}:${ppass}@${phost}`,
    tunnel: true
}).once('request', onRequest)
```

This also solves #49 (@hashexclude: I think you want the tunnel response per request)